### PR TITLE
Add support for detecting the precense of a Neo4j `AuthTokenManager` bean.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfigurationIntegrationTests.java
@@ -18,7 +18,11 @@ package org.springframework.boot.autoconfigure.neo4j;
 
 import java.time.Duration;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokenManager;
+import org.neo4j.driver.AuthTokenManagers;
+import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
@@ -31,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testsupport.testcontainers.DockerImageNames;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -43,7 +48,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Michael J. Simons
  * @author Stephane Nicoll
  */
-@SpringBootTest
 @Testcontainers(disabledWithoutDocker = true)
 class Neo4jAutoConfigurationIntegrationTests {
 
@@ -52,28 +56,71 @@ class Neo4jAutoConfigurationIntegrationTests {
 		.withStartupAttempts(5)
 		.withStartupTimeout(Duration.ofMinutes(10));
 
-	@DynamicPropertySource
-	static void neo4jProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.neo4j.uri", neo4jServer::getBoltUrl);
-		registry.add("spring.neo4j.authentication.username", () -> "neo4j");
-		registry.add("spring.neo4j.authentication.password", neo4jServer::getAdminPassword);
-	}
+	@SpringBootTest
+	@Nested
+	class DriverWithDefaultAuthToken {
 
-	@Autowired
-	private Driver driver;
-
-	@Test
-	void driverCanHandleRequest() {
-		try (Session session = this.driver.session(); Transaction tx = session.beginTransaction()) {
-			Result statementResult = tx.run("MATCH (n:Thing) RETURN n LIMIT 1");
-			assertThat(statementResult.hasNext()).isFalse();
-			tx.commit();
+		@DynamicPropertySource
+		static void neo4jProperties(DynamicPropertyRegistry registry) {
+			registry.add("spring.neo4j.uri", neo4jServer::getBoltUrl);
+			registry.add("spring.neo4j.authentication.username", () -> "neo4j");
+			registry.add("spring.neo4j.authentication.password", neo4jServer::getAdminPassword);
 		}
+
+		@Autowired
+		private Driver driver;
+
+		@Test
+		void driverCanHandleRequest() {
+			try (Session session = this.driver.session(); Transaction tx = session.beginTransaction()) {
+				Result statementResult = tx.run("MATCH (n:Thing) RETURN n LIMIT 1");
+				assertThat(statementResult.hasNext()).isFalse();
+				tx.commit();
+			}
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		@ImportAutoConfiguration(Neo4jAutoConfiguration.class)
+		static class TestConfiguration {
+
+		}
+
 	}
 
-	@Configuration(proxyBeanMethods = false)
-	@ImportAutoConfiguration(Neo4jAutoConfiguration.class)
-	static class TestConfiguration {
+	@SpringBootTest
+	@Nested
+	class DriverWithDynamicAuthToken {
+
+		@DynamicPropertySource
+		static void neo4jProperties(DynamicPropertyRegistry registry) {
+			registry.add("spring.neo4j.uri", neo4jServer::getBoltUrl);
+			registry.add("spring.neo4j.authentication.username", () -> "wrong");
+			registry.add("spring.neo4j.authentication.password", () -> "alsowrong");
+		}
+
+		@Autowired
+		private Driver driver;
+
+		@Test
+		void driverCanHandleRequest() {
+			try (Session session = this.driver.session(); Transaction tx = session.beginTransaction()) {
+				Result statementResult = tx.run("MATCH (n:Thing) RETURN n LIMIT 1");
+				assertThat(statementResult.hasNext()).isFalse();
+				tx.commit();
+			}
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		@ImportAutoConfiguration(Neo4jAutoConfiguration.class)
+		static class TestConfiguration {
+
+			@Bean
+			AuthTokenManager authTokenManager() {
+				return AuthTokenManagers.expirationBased(() -> AuthTokens.basic("neo4j", neo4jServer.getAdminPassword())
+					.expiringAt(System.currentTimeMillis() + 5_000));
+			}
+
+		}
 
 	}
 


### PR DESCRIPTION
Neo4j Java driver introduced support for an `AuthTokenManager` that can be used to define expiring tokens to be used as authentication with a database.

This commit adds a  `ObjectProvider<AuthTokenManager> authTokenManagers` parameter to the corresponding auto configuration class. If the provider resolves to a unique object, that `AuthTokenManager` will have precedence over any static token.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
