### PR TITLE
Improve Jackson configuration for the actuator endpoints to include package private constructors.

### DIFF
--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/jackson/JacksonEndpointAutoConfiguration.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/jackson/JacksonEndpointAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.endpoint.jackson;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -42,6 +43,7 @@ public final class JacksonEndpointAutoConfiguration {
 		JsonMapper jsonMapper = JsonMapper.builder()
 			.changeDefaultPropertyInclusion(
 					(value) -> value.withValueInclusion(Include.NON_NULL).withContentInclusion(Include.NON_NULL))
+			.changeDefaultVisibility(vc -> vc.withCreatorVisibility(Visibility.NON_PRIVATE))
 			.build();
 		return () -> jsonMapper;
 	}

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/jackson/JacksonEndpointAutoConfigurationTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/jackson/JacksonEndpointAutoConfigurationTests.java
@@ -25,7 +25,10 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.jackson.example.SomeResponseBody;
+import org.springframework.boot.actuate.endpoint.OperationResponseBody;
 import org.springframework.boot.actuate.endpoint.jackson.EndpointJsonMapper;
+import org.springframework.boot.actuate.web.mappings.MappingsEndpoint.ApplicationMappingsDescriptor;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -89,6 +92,23 @@ class JacksonEndpointAutoConfigurationTests {
 			String json = jsonMapper.writeValueAsString(map);
 			assertThat(json).isEqualTo("{}");
 		});
+	}
+
+	@Test
+	void endpointShouldDeserializeOperationResponseBodies() {
+		this.runner.run((context) -> {
+			JsonMapper jsonMapper = context.getBean(EndpointJsonMapper.class).get();
+			String json = """
+					{
+					"value1": "a",
+					"value2": "b",
+					}
+					""";
+			SomeResponseBody responseBody = jsonMapper.readValue(json, SomeResponseBody.class);
+			assertThat(responseBody.getValue1()).isEqualTo("a");
+			assertThat(responseBody.getValue2()).isEqualTo("b");
+		});
+
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/jackson/example/SomeResponseBody.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/jackson/example/SomeResponseBody.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.endpoint.jackson.example;
+
+import org.springframework.boot.actuate.endpoint.OperationResponseBody;
+
+/**
+ * A class that reassembles something like
+ * {@code org.springframework.boot.micrometer.metrics.actuate.endpoint.MetricsEndpoint.MetricDescriptor},
+ * not exposing a public constructor, only package level. They could be deserialized with
+ * Jackson 2 out of the box, but not with Jackson 3 anymore. Constructors with one
+ * argument still deserialize as is, so this need to have two or more.
+ *
+ * @author Michael J. Simons
+ */
+public final class SomeResponseBody implements OperationResponseBody {
+
+	private final String value1;
+
+	private final String value2;
+
+	SomeResponseBody(String value1, String value2) {
+		this.value1 = value1;
+		this.value2 = value2;
+	}
+
+	public String getValue1() {
+		return this.value1;
+	}
+
+	public String getValue2() {
+		return this.value2;
+	}
+
+}


### PR DESCRIPTION
Jackson 3 does not detected package private constructors anyore in case they have more than one argument. This prevents the Restclient / Resttemplate and their test derivates deserializing metrics endpoints as they could do in Spring Boot 3.x with Jackson 2.

This changes the isolated mapper to the behaviour of Jackson 2, so that the mapping works out of the box again.

Signed-off-by: Michael Simons <michael@simons.ac>

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
